### PR TITLE
Fix top-scrolling bug

### DIFF
--- a/index.css
+++ b/index.css
@@ -60,7 +60,7 @@
     position: absolute;
     bottom: 0;
     max-height: 100%;
-    padding: 0 2px;
+    padding: 10px 2px 0 2px;
 }
 #msg {
     height: 100%;


### PR DESCRIPTION
This fixes the bug where the text in the history window cannot be
scrolled to the very first line, but it remains somewhat hidden behind
the header navbar.

Previous UI:
<img width="783" alt="screen shot 2015-07-07 at 12 01 39 am" src="https://cloud.githubusercontent.com/assets/544572/8534304/6abfeda6-243b-11e5-9c0e-2e72a87576b7.png">

Fixed UI:
<img width="603" alt="screen shot 2015-07-07 at 12 01 21 am" src="https://cloud.githubusercontent.com/assets/544572/8534311/76f936b8-243b-11e5-8ed6-d19f2bb78eca.png">
