### PR TITLE
Fix bottom scrolling bug

### DIFF
--- a/client.js
+++ b/client.js
@@ -8,7 +8,9 @@ $(document).ready(function() {
     var socket = io.connect(URL);
 
     function scrollDown() {
-        wrapper.scrollTop(wrapper.get(0).scrollHeight);
+        setTimeout(function() {
+            wrapper.scrollTop(wrapper.get(0).scrollHeight);
+        }, 30);
     }
 
     $('#username-set-modal').modal('show');


### PR DESCRIPTION
This fixes the bug where new messages would not be scrolled-to. Instead,
the last-but-one message was scrolled to.
