### PR TITLE
Self messages

### DIFF
--- a/client.js
+++ b/client.js
@@ -44,11 +44,8 @@ $(document).ready(function() {
     $.getJSON('/api/messages/' + channel, function(msgs) {
         $.each(msgs, function(index, msg) {
             var src = getAvatar(msg.username);
-            var $img = $('<img src="' + src + '" alt="' + msg.username + '" />');
+            var $img = $('<img src="' + src + '" alt="' + msg.username + '" class="avatar" />');
             var $li = $('<li></li>');
-
-            $img.width(20);
-            $img.height(20);
 
             $li.append($img);
             $li.append(document.createTextNode(' '));
@@ -109,7 +106,7 @@ $(document).ready(function() {
 
     socket.on('chat', function(who, msg) {
         if (ready) {
-            var avatarHTML = '<img src="' + getAvatar(who) + '" alt="' + who + '" width="20" height="20"/>';
+            var avatarHTML = '<img src="' + getAvatar(who) + '" alt="' + who + '" class="avatar"/>';
             var class;
 
             if (who == myUsername) {

--- a/index.css
+++ b/index.css
@@ -37,8 +37,10 @@
 .history li {
     padding: 4px 0;
 }
-.history img {
+.history img.avatar {
     border-radius: 50px;
+    width: 20px;
+    height: 20px;
 }
 .textarea {
     position: absolute;


### PR DESCRIPTION
This patch introduces mainly visual fixes:
- Your messages and others' messages are shown in different colours
- The text in the textarea and in the history are now aligned on the left
- Minor refactoring in the client.js code; local username is kept as state

<img width="172" alt="screen shot 2015-07-08 at 1 56 44 am" src="https://cloud.githubusercontent.com/assets/544572/8560084/9d0dc1fa-2514-11e5-8b11-2568cabcaf33.png">
