### PR TITLE
Visual fix: Add space after username in history

### DIFF
--- a/client.js
+++ b/client.js
@@ -51,6 +51,7 @@ $(document).ready(function() {
             $img.height(20);
 
             $li.append($img);
+            $li.append(document.createTextNode(' '));
             $li.append($('<strong>' + msg.username + '</strong>'));
             $li[0].innerHTML += ': ' + msg.text;
 


### PR DESCRIPTION
Fixes the problem where avatars and usernames are overlapping in history:

<img width="289" alt="screen shot 2015-07-08 at 2 49 50 am" src="https://cloud.githubusercontent.com/assets/544572/8560786/057d5690-251c-11e5-97f5-5f4c78f7e988.png">
