### PR TITLE
Use Github for avatars instead of Gravatar

### DIFF
--- a/client.js
+++ b/client.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
     }
 
     function getAvatar(name) {
-        return 'http://www.gravatar.com/avatar/' + md5(name.toLowerCase() + '@gmail.com');
+        return 'https://avatars.githubusercontent.com/' + name.toLowerCase();
     }
 
     $.getJSON('/api/messages/' + channel, function(msgs) {


### PR DESCRIPTION
Turns this:
<img width="311" alt="screenshot 2015-07-12 20 26 25" src="https://cloud.githubusercontent.com/assets/732062/8638992/56d20070-28d4-11e5-9a55-a8f1e638eb85.png">

into this:
<img width="222" alt="screenshot 2015-07-12 20 23 51" src="https://cloud.githubusercontent.com/assets/732062/8638993/5b57a9a6-28d4-11e5-86e2-d8f8a79b32d7.png">

Since we only have a username, it's more suitable for our current use case to use Github for avatars instead of Gravatar than assume everyone has a `$username@gmail.com` account.
