### PR TITLE
Use the correct part of the URL to indentify the channel.

### DIFF
--- a/client.js
+++ b/client.js
@@ -51,7 +51,7 @@ $(document).ready(function() {
 
     var url = $(location).attr('href');
     parts = url.split('/');
-    var channel = parts[1];
+    var channel = parts.slice(-1)[0]
 
     if (channel == '') {
         channel = 'ting';


### PR DESCRIPTION
The problem was that if the link had the form:
`http://ting.gr/dev/'
the`parts`array would be
`[http, "", "ting", "dev"]`
