### PR TITLE
Disallow sending of empty messages

### DIFF
--- a/client.js
+++ b/client.js
@@ -105,7 +105,7 @@ $(document).ready(function() {
             e.preventDefault();
 
             var msg = $('#msg input').val();
-            if (msg != '') {
+            if (msg.trim().length > 0) {
                 if (first) {
                     ga('send', 'event', { 
                         eventCategory: 'chat', eventAction: 'chat_form_submit', eventLabel: 'send', eventValue: 1


### PR DESCRIPTION
We previously checked for the message string not to be '' but we also
need to account for whitespace.
