### PR TITLE
Several updates in architecture document.

### DIFF
--- a/etc/spec/ARCHITECTURE.md
+++ b/etc/spec/ARCHITECTURE.md
@@ -159,15 +159,13 @@ There are four operations:
    body contains a dictionary with four keys, `text`, `username`,
    `datetime_start` and `typing`, with the semantics above.
 
-3. A PATCH operation on `/messages/<channel_name>`. This is a **privileged
-   operation** that updates a message on a given channel. The PATCH body
-   contains a dictionary with four keys `text`, `id`, `datetime_sent`
-   and `typing`, with the semantics above. `id` is used for searching, while
-   `text`, `datetime_sent` and `typing` are used as the fields to update.
+3. A PATCH operation on `/messages/<id>`. This is a **privileged
+   operation** that updates a message with a given id. The PATCH body
+   contains a dictionary with three keys `text`, `datetime_sent`
+   and `typing`, with the semantics above, and with the values to update.
 
-4. A DELETE operation on `/messages/<channel_name>`. This is a **privileged
-   operation** that deletes a message on a given channel. The DELETE body
-   contains a dictionary with one key `id`, with the semantics above.
+4. A DELETE operation on `/messages/<id>`. This is a **privileged
+   operation** that deletes a given message.
 
 ### Channels
 The Channels resource is used to create and retrieve channel information.


### PR DESCRIPTION
This is a collaborative pull request between @VitSalis and @dionyziz
- Update architecture diagram and client-side architecture description to
  reflect our migration to the react framework.
- Django API is now versioned and the first version is indicated in the URL as
  v1.
- POST and PATCH operations for messages now address messages by id.
- Conversations are now supported in all API end-points and are addressed by
  the tuple (type, target).
- Users online are no longer monitored per-channel but in a global basis.
- Small grammar fixes.
