### PR TITLE
Log error when realtime can't connect to API

### DIFF
--- a/realtime/server.js
+++ b/realtime/server.js
@@ -71,7 +71,12 @@ socket.on('connection', function (client) {
 
         req(options, function(error, response, body) {
             if (error) {
-                winston.error('Message from user: ' + data.username + " couldn't be sent to Django. Error: " + error);
+                winston.error('Message from user: ' +
+                    data.username +
+                    " couldn't be sent to Django (" +
+                    options.url +
+                    "). " +
+                    error);
             }
         });
     });


### PR DESCRIPTION
This replaces the non-existent winston.warning call with the appropriate error debugging and also shows the failed request URL.
