### PR TITLE
[HOTFIX] Remove replaces line on 0001_squashed

### DIFF
--- a/API/chat/migrations/0001_squashed_0002_auto_20150707_1647.py
+++ b/API/chat/migrations/0001_squashed_0002_auto_20150707_1647.py
@@ -6,8 +6,6 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'chat', '0001_squashed_0008_auto_20150702_1437'), (b'chat', '0002_auto_20150707_1647')]
-
     dependencies = [
     ]
 


### PR DESCRIPTION
If you've already run the migrations that 0001_squashed replaces, just run

`python manage.py migrate --fake` in order to apply the other migrations.
