### PR TITLE
Revert "Revert "[HOTFIX] Remove replaces line on 0001_squashed""

### DIFF
--- a/API/chat/migrations/0001_squashed_0002_auto_20150707_1647.py
+++ b/API/chat/migrations/0001_squashed_0002_auto_20150707_1647.py
@@ -6,8 +6,6 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'chat', '0001_squashed_0008_auto_20150702_1437'), (b'chat', '0002_auto_20150707_1647')]
-
     dependencies = [
     ]
 


### PR DESCRIPTION
Reverts dionyziz/ting#109

As of this point, we will no longer squash any django migrations. It complicated deployment tremendously and there is no sufficient supporting documentation or help from the django community to provide any evidence that this is the practice used by the django community.

[Stack overflow](http://stackoverflow.com/questions/26007045/why-do-migrations-fail-on-test-but-not-on-migrate) and [stack overflow](http://stackoverflow.com/questions/28668351/django-dependencies-reference-nonexistent-parent-node), as well as questions on django on freenode did not provide sufficient answers as to why [our problems](https://gist.github.com/dionyziz/dc9dae0fd5cf8eedaca7) occurred. 

Unless we can figure out why the squashed dependencies are unable to work with dependents and sufficiently document the deployment failure in a post-mortem, squashed migrations will be avoided.

@Geekfish @VitSalis 
