### PR TITLE
Improve message styling

### DIFF
--- a/client/index.css
+++ b/client/index.css
@@ -40,6 +40,7 @@
     padding: 4px 0;
     margin: 0;
     display: flex;
+    align-items: center;
 }
 .history li:last-child {
     margin-bottom: 4px;
@@ -48,6 +49,7 @@
     border-radius: 50px;
     width: 20px;
     height: 20px;
+    min-width: 20px;
     margin-right: 5px;
 }
 .textarea {
@@ -83,7 +85,6 @@
     line-height: 15px;
     min-width: 25px;
     word-wrap: break-word;
-    top: -2px;
     cursor: text;
 }
 .chat ul .self div {
@@ -126,7 +127,7 @@ ul {
     display: block;
     position: absolute;
     left: -8px;
-    top: 8px;
+    top: calc(50% - 0.5em);
     color: #f1f0f0;
     font-weight: bold;
 }


### PR DESCRIPTION
* Vertically center the avatar/username on long messages.
* Make sure the bubble nose points to the middle of the username.

<img width="1680" alt="screen shot 2017-09-15 at 20 33 20" src="https://user-images.githubusercontent.com/732062/30496741-0a2dd4e4-9a59-11e7-860b-4041fed13e25.png">
